### PR TITLE
Feature: 학교 랭킹 배너, 푼문제 비교 컴포넌트 UI 구현

### DIFF
--- a/src/components/home/banner/Banner.jsx
+++ b/src/components/home/banner/Banner.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+import BannerBox from "../bannerBox/BannerBox";
+import styles from "./banner.module.css";
+
+function Banner() {
+  return (
+    <section className={styles.banner}>
+      <div className={styles.container}>
+        <BannerBox rank="66" name="펍지" correct="4714" />
+        <BannerBox rank="67" name="한국외국어대" correct="4691" main={true} />
+        <BannerBox rank="68" name="단국대학교" correct="4539" />
+      </div>
+    </section>
+  );
+}
+
+export default Banner;

--- a/src/components/home/banner/banner.module.css
+++ b/src/components/home/banner/banner.module.css
@@ -1,0 +1,15 @@
+.banner {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  padding: 5.5rem 0 7rem;
+  background-color: var(--color-primary);
+  color: var(--color-border);
+}
+
+.container {
+  width: 100%;
+  max-width: 140rem;
+  display: flex;
+  justify-content: space-between;
+}

--- a/src/components/home/bannerBox/BannerBox.jsx
+++ b/src/components/home/bannerBox/BannerBox.jsx
@@ -1,0 +1,16 @@
+import React from "react";
+import styles from "./bannerBox.module.css";
+
+function BannerBox({ main, rank, name, correct }) {
+  return (
+    <div className={`${styles.container} ${main && styles.main}`}>
+      <p className={styles.rank}>
+        <span>{rank}</span>위
+      </p>
+      <strong className={styles.name}>{name}</strong>
+      <p className={styles.correct}>맞은 문제 수 : {correct}</p>
+    </div>
+  );
+}
+
+export default BannerBox;

--- a/src/components/home/bannerBox/bannerBox.module.css
+++ b/src/components/home/bannerBox/bannerBox.module.css
@@ -1,0 +1,52 @@
+.container {
+  position: relative;
+  margin: 0 auto;
+  width: 29rem;
+  height: 18rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  border: var(--color-white) 1px solid;
+}
+
+.container.main {
+  border: var(--color-main) 0.3rem solid;
+}
+
+.rank {
+  position: absolute;
+  left: 50%;
+  top: 0;
+  transform: translate(-50%, -50%);
+  padding: 0 2.5rem;
+  font-size: 2.6rem;
+  border: 1px solid var(--color-secondary);
+  border-radius: 1rem;
+  color: var(--color-secondary);
+  background-color: var(--color-white);
+}
+
+.rank span {
+  font-weight: var(--weight-semi-bold);
+}
+
+.name {
+  font-size: 3em;
+  font-weight: var(--weight-semi-bold);
+  line-height: 4.4rem;
+}
+
+.container.main .name {
+  font-size: 3.2rem;
+}
+
+.correct {
+  font-size: 2.2rem;
+  line-height: 2.8rem;
+}
+
+.container.main .correct {
+  font-size: 2.4rem;
+}

--- a/src/components/home/rankBox/RankBox.jsx
+++ b/src/components/home/rankBox/RankBox.jsx
@@ -1,0 +1,67 @@
+import React from "react";
+import styles from "./rankbox.module.css";
+
+function RankBox() {
+  const dummyData = {
+    hufsRank: 67,
+    hufsTotalSolved: 4691,
+    hufsWeekSolved: 15,
+    frontName: "펍지",
+    frontTotalSolved: 4714,
+    frontWeekSolved: 23,
+    behindName: "단국대학교",
+    behindTotalSolved: 4539,
+    behindWeekSolved: 30,
+  };
+
+  return (
+    <div className={styles.container}>
+      <article className={`${styles.box} ${styles.first}`}>
+        <h3 className={styles.title}>
+          현재 한국외국어대학교 순위는 <strong>{dummyData.hufsRank}</strong>
+          &nbsp;위 입니다.
+        </h3>
+        <div className={styles.text}>
+          <p>
+            66위인 <span>펍지</span>를 따라잡기까지&nbsp;
+            <strong>
+              {dummyData.frontTotalSolved - dummyData.hufsTotalSolved}
+            </strong>
+            &nbsp;문제가 남았고,
+          </p>
+          <p>
+            68위인 <span>단국대학교</span>에게 따라잡히기 까지&nbsp;
+            <strong>
+              {dummyData.hufsTotalSolved - dummyData.behindTotalSolved}
+            </strong>
+            &nbsp;문제가 남았습니다.
+          </p>
+        </div>
+        <button className={styles.button}>전체 순위 보기</button>
+      </article>
+      <article className={`${styles.box} ${styles.second}`}>
+        <h3 className={styles.title}>
+          이번주 한국외국어대학교가 푼 문제는&nbsp;
+          <strong>{dummyData.hufsWeekSolved}</strong>&nbsp;문제 입니다.
+        </h3>
+        <div className={styles.text}>
+          <p>
+            {dummyData.hufsRank - 1}위인 <span>펍지</span>는 이번주 총&nbsp;
+            <strong>{dummyData.frontWeekSolved}</strong>&nbsp;문제를 풀었고,
+          </p>
+          <p>
+            {dummyData.hufsRank + 1}위인 <span>단국대학교</span>는 이번주
+            총&nbsp;
+            <strong>{dummyData.behindWeekSolved}</strong>&nbsp; 문제를
+            풀었습니다.
+          </p>
+        </div>
+        <p className={styles.text}>
+          한국외국어대학교의 백준 랭킹 상승을 위해 한문제 더 풀어주세요!
+        </p>
+      </article>
+    </div>
+  );
+}
+
+export default RankBox;

--- a/src/components/home/rankBox/rankbox.module.css
+++ b/src/components/home/rankBox/rankbox.module.css
@@ -1,0 +1,64 @@
+.container {
+  width: 100%;
+  max-width: 140rem;
+  display: flex;
+  justify-content: space-between;
+}
+
+.box {
+  background-color: var(--color-white-grey);
+  border-radius: 1.5rem;
+  padding: 4rem 4rem 2.5rem;
+}
+
+.box.first button {
+  margin-top: 3.9rem;
+}
+
+.box.second div {
+  margin-bottom: 3.1rem;
+}
+
+.title {
+  margin-bottom: 0.7rem;
+  color: var(--color-primary);
+  font-size: 2.2rem;
+  line-height: 4.4rem;
+}
+
+.title strong {
+  font-weight: var(--weight-semi-bold);
+  color: var(--color-red);
+  font-size: 3.6rem;
+  vertical-align: bottom;
+}
+
+.text {
+  font-size: 1.6rem;
+  line-height: 2.4rem;
+  color: var(--color-secondary);
+}
+
+.text span,
+.text strong {
+  font-weight: var(--weight-semi-bold);
+}
+
+.text strong {
+  color: var(--color-blue);
+}
+
+.button {
+  padding: 0.6rem 1.6rem;
+  border-radius: 1rem;
+  background-color: var(--color-white-blue);
+  color: var(--color-blue);
+  font-weight: var(--weight-bold);
+  transition: var(--transition-smooth);
+  border: 1px solid transparent;
+}
+
+.button:hover {
+  background-color: var(--color-white);
+  border: 1px solid var(--color-blue);
+}


### PR DESCRIPTION
## 작업내용
- #2 
- 학교 랭킹 배너
- 푼문제 비교 컴포넌트 UI 를 구현하였습니다. 
- 사용되는 데이터는 일단 더미데이터로 넣어두었습니다. <br/>
![image](https://user-images.githubusercontent.com/68495264/230758805-f4a5347e-41a6-4830-9111-cc87af238180.png)


## check📝
- [X]  PR 하나에 기능 하나만 넣었나요?
- [X]  PR에 이슈를 링크했나요?
- [X]  의미 있는 커밋 메시지를 작성하셨나요?
